### PR TITLE
fix: getdefaultlocale may return None

### DIFF
--- a/appteka/distrib.py
+++ b/appteka/distrib.py
@@ -42,7 +42,7 @@ def build_folder_name(name, version, appendix=None):
 def init_translation(package_name, resource_name, module_name):
     """Return function for specifying of places to be translated."""
 
-    lang = locale.getdefaultlocale()[0]
+    lang = locale.setlocale(locale.LC_CTYPE, None)
     gettext.install(module_name)
 
     def _echo(text):


### PR DESCRIPTION
locale.getdefaultlocale was deprecated: [https://github.com/python/cpython/issues/90817](url)
Passing None to locale.setlocale returns the current locale setting.
